### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Dashboard][https://www.twilio.com/user/account/] page.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``send_sms`` - Action which sends an SMS using Twilio API.

--- a/actions/send_sms.yaml
+++ b/actions/send_sms.yaml
@@ -1,6 +1,6 @@
 ---
 name: send_sms
-runner_type: run-python
+runner_type: python-script
 description: This sends a SMS using twilio.
 enabled: true
 entry_point: send_sms.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: twilio
 name : twilio
 description : st2 content pack containing twilio integrations
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.